### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-
 # MCP-Server (OnePieceServer & Geolocalizar)
 
 Este proyecto contiene dos servidores MCP desarrollados con [`@modelcontextprotocol/sdk`](https://www.npmjs.com/package/@modelcontextprotocol/sdk). Cada uno expone una herramienta útil que puede ser integrada por un cliente AI compatible con MCP.
+
+<a href="https://glama.ai/mcp/servers/@Haonter/MCP-Servers">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Haonter/MCP-Servers/badge" alt="Servers (OnePiece & Geolocalizar) MCP server" />
+</a>
 
 ---
 


### PR DESCRIPTION
This PR adds a badge for the [MCP Servers (OnePiece & Geolocalizar)](https://glama.ai/mcp/servers/@Haonter/MCP-Servers) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Haonter/MCP-Servers">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Haonter/MCP-Servers/badge" alt="Servers (OnePiece & Geolocalizar) MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.